### PR TITLE
Fix bug with rewriting external files

### DIFF
--- a/include/transformations/AddCommentsTransformation.h
+++ b/include/transformations/AddCommentsTransformation.h
@@ -21,7 +21,7 @@
 #include "../ITransformation.h"
 
 using clang::ASTConsumer, clang::Rewriter, clang::RecursiveASTVisitor,
-clang::DeclGroupRef, clang::Stmt;
+clang::DeclGroupRef, clang::Stmt, clang::SourceManager;
 using std::unique_ptr, std::vector, std::string;
 
 /// RecursiveASTVisitor is a set of actions that are done
@@ -35,6 +35,7 @@ class AddCommentsVisitor : public RecursiveASTVisitor<AddCommentsVisitor> {
     bool VisitStmt(Stmt *s);
  private:
     Rewriter * rewriter;
+    SourceManager & sm;
     const vector<string> * statements;
     /**
      * Check if vector statements contains a specific statement

--- a/include/transformations/IfElseSwapTransformation.h
+++ b/include/transformations/IfElseSwapTransformation.h
@@ -32,13 +32,13 @@ class IfElseSwapVisitor : public RecursiveASTVisitor<IfElseSwapVisitor> {
     /**
      * This function is called a certain clang::Stmt is visited
      */
-    bool VisitStmt(Stmt *s);
+    bool VisitIfStmt(IfStmt * ifStmt);
  private:
     Rewriter * rewriter;
     SourceManager & sm;
     LangOptions opt;
     vector<IfStmt *> visitedIfStmt;
-    bool isNotVisited(IfStmt * s);
+    bool isNotVisited(IfStmt * ifStmt);
     void swapBodies(IfStmt * ifStmt);
     void rewriteCondition(IfStmt * ifStmt);
     void processIfStmt(IfStmt * ifStmt);

--- a/include/transformations/RenameEntitiesTransformation.h
+++ b/include/transformations/RenameEntitiesTransformation.h
@@ -23,7 +23,7 @@
 #include "../ITransformation.h"
 
 using clang::ASTConsumer, clang::Rewriter, clang::RecursiveASTVisitor,
-clang::ASTContext, clang::CallExpr, clang::Decl, clang::Stmt;
+clang::ASTContext, clang::CallExpr, clang::Decl, clang::Stmt, clang::SourceManager;
 using std::unique_ptr, std::vector, std::map, std::string, std::mt19937,
 std::discrete_distribution;
 
@@ -51,6 +51,7 @@ class RenameEntitiesVisitor : public RecursiveASTVisitor<RenameEntitiesVisitor> 
 
  private:
     Rewriter * rewriter;
+    SourceManager & sm;
 
     const bool rename_func = false;
     const bool rename_var = false;

--- a/include/transformations/ReorderFuncDeclsTransformation.h
+++ b/include/transformations/ReorderFuncDeclsTransformation.h
@@ -22,7 +22,7 @@
 
 #include "../ITransformation.h"
 
-using clang::ASTConsumer, clang::Rewriter, clang::RecursiveASTVisitor,
+using clang::ASTConsumer, clang::Rewriter, clang::RecursiveASTVisitor, clang::SourceManager,
 clang::ASTContext, clang::CallExpr, clang::SourceLocation, clang::FunctionDecl;
 using std::unique_ptr, std::vector, std::map, std::string, std::mt19937,
 std::discrete_distribution;
@@ -47,7 +47,7 @@ class ReorderFuncDeclsVisitor : public RecursiveASTVisitor<ReorderFuncDeclsVisit
 
  private:
     Rewriter * rewriter;
-
+    SourceManager & sm;
     mt19937 * gen;
 
     const bool test = false;

--- a/src/transformations/AddCommentsTransformation.cpp
+++ b/src/transformations/AddCommentsTransformation.cpp
@@ -7,10 +7,11 @@ using std::unique_ptr, std::find, std::vector, std::string;
 // ------------ AddCommentsVisitor ------------
 
 AddCommentsVisitor::AddCommentsVisitor(Rewriter * rewriter, const vector<string> * statements) :
-                                       rewriter(rewriter), statements(statements) {}
+                                       rewriter(rewriter), sm(rewriter->getSourceMgr()), statements(statements) {}
 
 bool AddCommentsVisitor::VisitStmt(Stmt *s) {
-    if (isa<IfStmt>(s)) {
+    auto loc = s->getBeginLoc();
+    if (isa<IfStmt>(s) && sm.isWrittenInMainFile(loc)) {
         auto IfStatement = cast<IfStmt>(s);
         if (containStatement(ifInside)) {
             rewriter->InsertText(IfStatement->getThen()->getBeginLoc(), "/* 'if' inside */\n",

--- a/src/transformations/ForToWhileTransformation.cpp
+++ b/src/transformations/ForToWhileTransformation.cpp
@@ -11,17 +11,19 @@ ForToWhileVisitor::ForToWhileVisitor(Rewriter * rewriter) :
         rewriter(rewriter), sm(rewriter->getSourceMgr()), opt(rewriter->getLangOpts()) {}
 
 bool ForToWhileVisitor::VisitForStmt(ForStmt * forStmt) {
-    const Stmt * body = forStmt->getBody();
+    auto loc = forStmt->getBeginLoc();
+    if (sm.isWrittenInMainFile(loc)) {
+        const Stmt *body = forStmt->getBody();
 
-    if (!body) {
-        return true;
+        if (!body) {
+            return true;
+        }
+
+        processInit(forStmt);
+        processCond(forStmt);
+        processInc(forStmt);
+        processBody(forStmt);
     }
-
-    processInit(forStmt);
-    processCond(forStmt);
-    processInc(forStmt);
-    processBody(forStmt);
-
     return true;
 }
 

--- a/src/transformations/IfElseSwapTransformation.cpp
+++ b/src/transformations/IfElseSwapTransformation.cpp
@@ -1,7 +1,5 @@
 #include "../../include/transformations/IfElseSwapTransformation.h"
 
-#include <iostream>
-
 using clang::IfStmt, clang::ForStmt, clang::WhileStmt;
 using clang::Lexer, clang::CharSourceRange;
 using llvm::isa, llvm::cast;
@@ -56,9 +54,9 @@ void IfElseSwapVisitor::processIfStmt(IfStmt * ifStmt) {
     }
 }
 
-bool IfElseSwapVisitor::VisitStmt(Stmt *s) {
-    if (isa<IfStmt>(s)) {
-        auto ifStmt = cast<IfStmt>(s);
+bool IfElseSwapVisitor::VisitIfStmt(IfStmt * ifStmt) {
+    auto loc = ifStmt->getBeginLoc();
+    if (sm.isWrittenInMainFile(loc)) {
         if (ifStmt->hasElseStorage()) {
             processIfStmt(ifStmt);
         }
@@ -66,8 +64,8 @@ bool IfElseSwapVisitor::VisitStmt(Stmt *s) {
     return true;
 }
 
-bool IfElseSwapVisitor::isNotVisited(IfStmt * s) {
-    return find(visitedIfStmt.begin(), visitedIfStmt.end(), s) == visitedIfStmt.end();
+bool IfElseSwapVisitor::isNotVisited(IfStmt * ifStmt) {
+    return find(visitedIfStmt.begin(), visitedIfStmt.end(), ifStmt) == visitedIfStmt.end();
 }
 
 // ------------ AddCommentsASTConsumer ------------

--- a/src/transformations/ReorderFuncDeclsTransformation.cpp
+++ b/src/transformations/ReorderFuncDeclsTransformation.cpp
@@ -1,5 +1,4 @@
 #include "../../include/transformations/ReorderFuncDeclsTransformation.h"
-#include <iostream>
 
 using llvm::isa, llvm::cast;
 using std::unique_ptr, std::sort, std::shuffle, std::find, std::reverse,
@@ -7,11 +6,13 @@ std::vector, std::string;
 using clang::SourceRange, clang::SourceManager, clang::FileID;
 
 ReorderFuncDeclsVisitor::ReorderFuncDeclsVisitor(Rewriter * rewriter, mt19937 * gen, const bool test) :
-                                                 rewriter(rewriter), gen(gen), test(test) {}
+                                                 rewriter(rewriter), sm(rewriter->getSourceMgr()),
+                                                 gen(gen), test(test) {}
 
 bool ReorderFuncDeclsVisitor::VisitFunctionDecl(FunctionDecl * decl) {
     if (!isFuncDeclProcessed(decl)) {
-        if (decl->isThisDeclarationADefinition()) {
+        auto loc = decl->getBeginLoc();
+        if (decl->isThisDeclarationADefinition() && sm.isWrittenInMainFile(loc)) {
             funcdecls.push_back(decl);
         }
     }

--- a/src/transformations/input_output/PrintfToCoutTransformation.cpp
+++ b/src/transformations/input_output/PrintfToCoutTransformation.cpp
@@ -13,16 +13,16 @@ PrintfToCoutVisitor::PrintfToCoutVisitor(Rewriter * rewriter) :
         rewriter(rewriter), sm(rewriter->getSourceMgr()), opt(rewriter->getLangOpts()) {}
 
 bool PrintfToCoutVisitor::VisitCallExpr(CallExpr *e) {
-    // Removing all sync_with_stdio expressions
-    auto const exprText = getAsText(SourceRange(e->getBeginLoc(), e->getEndLoc()));
-    if (exprText->find("sync_with_stdio") != string::npos) {
-        SourceRange rangeToDelete(e->getBeginLoc(),
-                                  e->getEndLoc().getLocWithOffset(2));
-        rewriter->ReplaceText(rangeToDelete, "");
-    }
-
-    // Collecting printf or std::printf expressions
     if (sm.isWrittenInMainFile(e->getBeginLoc())) {
+        // Removing all sync_with_stdio expressions
+        auto const exprText = getAsText(SourceRange(e->getBeginLoc(), e->getEndLoc()));
+        if (exprText->find("sync_with_stdio") != string::npos) {
+            SourceRange rangeToDelete(e->getBeginLoc(),
+                                      e->getEndLoc().getLocWithOffset(2));
+            rewriter->ReplaceText(rangeToDelete, "");
+        }
+
+        // Collecting printf or std::printf expressions
         SourceLocation LocStart = e->getBeginLoc();
         SourceLocation LocEnd = Lexer::getLocForEndOfToken(LocStart, 0, sm, opt);
         auto const exprToken = getAsText(SourceRange(LocStart, LocEnd));

--- a/tests/resources/expected/test_add_comments/transformation_0.cpp
+++ b/tests/resources/expected/test_add_comments/transformation_0.cpp
@@ -1,4 +1,8 @@
+#include <bits/stdc++.h>
+using namespace std;
+
 void foo(int n) {
+    cout << "hello";
     int i = 0;
     int j = 0;
     for (int i = 0; i < n; i++)

--- a/tests/resources/expected/test_add_comments/transformation_1.cpp
+++ b/tests/resources/expected/test_add_comments/transformation_1.cpp
@@ -1,4 +1,8 @@
+#include <bits/stdc++.h>
+using namespace std;
+
 void foo(int n) {
+    cout << "hello";
     int i = 0;
     int j = 0;
     /* 'for' begin */

--- a/tests/resources/expected/test_for_to_while/transformation_0.cpp
+++ b/tests/resources/expected/test_for_to_while/transformation_0.cpp
@@ -1,4 +1,8 @@
+#include <bits/stdc++.h>
+using namespace std;
+
 void a(int *x) {
+    cout << "hello";
     for(int i = 0; i < 4; ++i) {
         int d = 4;
     }

--- a/tests/resources/expected/test_for_to_while/transformation_1.cpp
+++ b/tests/resources/expected/test_for_to_while/transformation_1.cpp
@@ -1,4 +1,8 @@
+#include <bits/stdc++.h>
+using namespace std;
+
 void a(int *x) {
+    cout << "hello";
     int i = 0;
     while (i < 4) {
         int d = 4;

--- a/tests/resources/expected/test_if_else_swap/transformation_0.cpp
+++ b/tests/resources/expected/test_if_else_swap/transformation_0.cpp
@@ -1,4 +1,8 @@
+#include <bits/stdc++.h>
+using namespace std;
+
 int foo(int n) {
+    cout << "hello";
     if (n == 1) {
         int k = 0;
         int j = 0;

--- a/tests/resources/expected/test_if_else_swap/transformation_1.cpp
+++ b/tests/resources/expected/test_if_else_swap/transformation_1.cpp
@@ -1,4 +1,8 @@
+#include <bits/stdc++.h>
+using namespace std;
+
 int foo(int n) {
+    cout << "hello";
     if (!(n == 1)) int k = 4;
  else
         {

--- a/tests/resources/expected/test_remove_comments/transformation_0.cpp
+++ b/tests/resources/expected/test_remove_comments/transformation_0.cpp
@@ -1,3 +1,6 @@
+#include <bits/stdc++.h>
+using namespace std;
+
 class Class {
     /**
      * param:
@@ -10,6 +13,7 @@ public:
     //  \______>   |__|        |__|
 
     void ffff(int &S) {
+        cout << "hello";
         int totalset = 33;
         /*
          * comments

--- a/tests/resources/expected/test_remove_comments/transformation_1.cpp
+++ b/tests/resources/expected/test_remove_comments/transformation_1.cpp
@@ -1,3 +1,6 @@
+#include <bits/stdc++.h>
+using namespace std;
+
 class Class {
     
 public:
@@ -5,6 +8,7 @@ public:
     
 
     void ffff(int &S) {
+        cout << "hello";
         int totalset = 33;
         
         for(int i=0; i<S;){

--- a/tests/resources/expected/test_rename_entities/transformation_0.cpp
+++ b/tests/resources/expected/test_rename_entities/transformation_0.cpp
@@ -1,4 +1,8 @@
+#include <bits/stdc++.h>
+using namespace std;
+
 void do_math(int *x) {
+    cout << "hello";
     *x += 5;
 }
 

--- a/tests/resources/expected/test_rename_entities/transformation_1.cpp
+++ b/tests/resources/expected/test_rename_entities/transformation_1.cpp
@@ -1,4 +1,8 @@
+#include <bits/stdc++.h>
+using namespace std;
+
 void test_do_math(int *test_x) {
+    cout << "hello";
     *test_x += 5;
 }
 

--- a/tests/resources/expected/test_reorder_function_decls/transformation_0.cpp
+++ b/tests/resources/expected/test_reorder_function_decls/transformation_0.cpp
@@ -1,3 +1,56 @@
+#include <bits/stdc++.h>
+using namespace std;
+
+int external() {
+    int ti,tn;
+    scanf("%d",&tn);
+    int x,i,j,ans,n,p;
+    for(ti=0;ti<tn;ti++) {
+        scanf("%d",&n);
+        vector<bool> a(1010,0);
+        vector<bool> b(1010,0);
+        for(i=0;i<n;i++) {
+            scanf("%d",&p);
+            a[p] = 1;
+        }
+        for(i=0;i<n;i++) {
+            scanf("%d",&p);
+            b[p] = 1;
+        }
+
+        for(i=0;i<1010;i++) {
+            if(a[i]==1) {
+                printf("%d",i);
+                break;
+            }
+        }
+        i++;
+        for(;i<1010;i++) {
+            if(a[i]==1) {
+                printf(" %d",i);
+            }
+        }
+        printf("\n");
+
+        for(i=0;i<1010;i++) {
+            if(b[i]==1) {
+                printf("%d",i);
+                break;
+            }
+        }
+        i++;
+        for(;i<1010;i++) {
+            if(b[i]==1) {
+                printf(" %d",i);
+            }
+        }
+
+        printf("\n");
+    }
+
+    return 0;
+}
+
 void foo1(int n) {
     int x = 9;
 }
@@ -18,6 +71,7 @@ int main() {
     foo2(2);
     foo3(3);
     t();
+    external();
     return 0;
 }
 

--- a/tests/resources/expected/test_reorder_function_decls/transformation_1.cpp
+++ b/tests/resources/expected/test_reorder_function_decls/transformation_1.cpp
@@ -1,3 +1,8 @@
+#include <bits/stdc++.h>
+using namespace std;
+
+int external() ;
+
 void foo1(int n) ;
 
 void foo2(int n) ;
@@ -21,6 +26,7 @@ int main() {
     foo2(2);
     foo3(3);
     t();
+    external();
     return 0;
 }
 
@@ -39,5 +45,55 @@ void foo1(int n) {
 
 void foo() {
     int x;
+}
+
+int external() {
+    int ti,tn;
+    scanf("%d",&tn);
+    int x,i,j,ans,n,p;
+    for(ti=0;ti<tn;ti++) {
+        scanf("%d",&n);
+        vector<bool> a(1010,0);
+        vector<bool> b(1010,0);
+        for(i=0;i<n;i++) {
+            scanf("%d",&p);
+            a[p] = 1;
+        }
+        for(i=0;i<n;i++) {
+            scanf("%d",&p);
+            b[p] = 1;
+        }
+
+        for(i=0;i<1010;i++) {
+            if(a[i]==1) {
+                printf("%d",i);
+                break;
+            }
+        }
+        i++;
+        for(;i<1010;i++) {
+            if(a[i]==1) {
+                printf(" %d",i);
+            }
+        }
+        printf("\n");
+
+        for(i=0;i<1010;i++) {
+            if(b[i]==1) {
+                printf("%d",i);
+                break;
+            }
+        }
+        i++;
+        for(;i<1010;i++) {
+            if(b[i]==1) {
+                printf(" %d",i);
+            }
+        }
+
+        printf("\n");
+    }
+
+    return 0;
 }
 

--- a/tests/resources/expected/test_while_to_for/transformation_0.cpp
+++ b/tests/resources/expected/test_while_to_for/transformation_0.cpp
@@ -1,4 +1,8 @@
+#include <bits/stdc++.h>
+using namespace std;
+
 void a(int *x) {
+    cout << "hello";
     int f;
     while(1) {
         f = 5;

--- a/tests/resources/expected/test_while_to_for/transformation_1.cpp
+++ b/tests/resources/expected/test_while_to_for/transformation_1.cpp
@@ -1,4 +1,8 @@
+#include <bits/stdc++.h>
+using namespace std;
+
 void a(int *x) {
+    cout << "hello";
     int f;
     for ( ; 1; ) 
 {

--- a/tests/resources/input/test_add_comments.cpp
+++ b/tests/resources/input/test_add_comments.cpp
@@ -1,4 +1,8 @@
+#include <bits/stdc++.h>
+using namespace std;
+
 void foo(int n) {
+    cout << "hello";
     int i = 0;
     int j = 0;
     for (int i = 0; i < n; i++)

--- a/tests/resources/input/test_for_to_while.cpp
+++ b/tests/resources/input/test_for_to_while.cpp
@@ -1,4 +1,8 @@
+#include <bits/stdc++.h>
+using namespace std;
+
 void a(int *x) {
+    cout << "hello";
     for(int i = 0; i < 4; ++i) {
         int d = 4;
     }

--- a/tests/resources/input/test_if_else_swap.cpp
+++ b/tests/resources/input/test_if_else_swap.cpp
@@ -1,4 +1,8 @@
+#include <bits/stdc++.h>
+using namespace std;
+
 int foo(int n) {
+    cout << "hello";
     if (n == 1) {
         int k = 0;
         int j = 0;

--- a/tests/resources/input/test_remove_comments.cpp
+++ b/tests/resources/input/test_remove_comments.cpp
@@ -1,3 +1,6 @@
+#include <bits/stdc++.h>
+using namespace std;
+
 class Class {
     /**
      * param:
@@ -10,6 +13,7 @@ public:
     //  \______>   |__|        |__|
 
     void ffff(int &S) {
+        cout << "hello";
         int totalset = 33;
         /*
          * comments

--- a/tests/resources/input/test_rename_entities.cpp
+++ b/tests/resources/input/test_rename_entities.cpp
@@ -1,4 +1,8 @@
+#include <bits/stdc++.h>
+using namespace std;
+
 void do_math(int *x) {
+    cout << "hello";
     *x += 5;
 }
 

--- a/tests/resources/input/test_reorder_function_decls.cpp
+++ b/tests/resources/input/test_reorder_function_decls.cpp
@@ -1,3 +1,56 @@
+#include <bits/stdc++.h>
+using namespace std;
+
+int external() {
+    int ti,tn;
+    scanf("%d",&tn);
+    int x,i,j,ans,n,p;
+    for(ti=0;ti<tn;ti++) {
+        scanf("%d",&n);
+        vector<bool> a(1010,0);
+        vector<bool> b(1010,0);
+        for(i=0;i<n;i++) {
+            scanf("%d",&p);
+            a[p] = 1;
+        }
+        for(i=0;i<n;i++) {
+            scanf("%d",&p);
+            b[p] = 1;
+        }
+
+        for(i=0;i<1010;i++) {
+            if(a[i]==1) {
+                printf("%d",i);
+                break;
+            }
+        }
+        i++;
+        for(;i<1010;i++) {
+            if(a[i]==1) {
+                printf(" %d",i);
+            }
+        }
+        printf("\n");
+
+        for(i=0;i<1010;i++) {
+            if(b[i]==1) {
+                printf("%d",i);
+                break;
+            }
+        }
+        i++;
+        for(;i<1010;i++) {
+            if(b[i]==1) {
+                printf(" %d",i);
+            }
+        }
+
+        printf("\n");
+    }
+
+    return 0;
+}
+
 void foo1(int n) {
     int x = 9;
 }
@@ -18,6 +71,7 @@ int main() {
     foo2(2);
     foo3(3);
     t();
+    external();
     return 0;
 }
 

--- a/tests/resources/input/test_while_to_for.cpp
+++ b/tests/resources/input/test_while_to_for.cpp
@@ -1,4 +1,8 @@
+#include <bits/stdc++.h>
+using namespace std;
+
 void a(int *x) {
+    cout << "hello";
     int f;
     while(1) {
         f = 5;


### PR DESCRIPTION
I faced `segmentation fault` when ran `ReorderFuncDeclsTransformation` on real code. That issue occurred since in transformation we collected all functions declarations, even those that were defined outside the main file. The same behaviour has been found in other transformations
In this PR the issue is fixed and some additional tests are added