### PR TITLE
Fix for to while transformation

### DIFF
--- a/include/transformations/ForToWhileTransformation.h
+++ b/include/transformations/ForToWhileTransformation.h
@@ -6,6 +6,8 @@
 #include <string>
 #include <vector>
 #include <memory>
+#include <utility>
+#include <stack>
 
 #include "clang/AST/AST.h"
 #include "clang/AST/ASTConsumer.h"
@@ -22,8 +24,8 @@
 
 using clang::ASTConsumer, clang::Rewriter, clang::RecursiveASTVisitor,
 clang::ASTContext, clang::ForStmt, clang::SourceManager, clang::LangOptions,
-clang::ContinueStmt, clang::Stmt, clang::SourceRange;
-using std::unique_ptr, std::vector, std::string;
+clang::ContinueStmt, clang::Stmt, clang::SourceRange, clang::SourceLocation;
+using std::unique_ptr, std::vector, std::string, std::stack, std::pair;
 
 /// RecursiveASTVisitor is a set of actions that are done
 /// when a certain node of AST is reached
@@ -38,6 +40,7 @@ class ForToWhileVisitor : public RecursiveASTVisitor<ForToWhileVisitor> {
     Rewriter * rewriter;
     SourceManager & sm;
     LangOptions opt;
+    stack<pair<SourceLocation, string>> rewritingStack;
     void collectContinues(const Stmt * s, vector<const ContinueStmt *> *continues);
     void processBody(ForStmt * forStmt);
     void processInit(ForStmt * forStmt);

--- a/src/transformations/ForToWhileTransformation.cpp
+++ b/src/transformations/ForToWhileTransformation.cpp
@@ -1,7 +1,7 @@
 #include "../../include/transformations/ForToWhileTransformation.h"
-
-using clang::Expr, clang::ContinueStmt, clang::ValueStmt;
-using clang::Lexer, clang::CharSourceRange;
+#include <iostream>
+using clang::Expr, clang::ContinueStmt, clang::ValueStmt, clang::CompoundStmt;
+using clang::Lexer, clang::CharSourceRange, clang::SourceLocation;
 using llvm::isa, llvm::cast;
 using std::unique_ptr, std::find, std::vector, std::string;
 
@@ -90,16 +90,27 @@ void ForToWhileVisitor::processInc(ForStmt * forStmt) {
             rewriter->InsertText(countinue_stmt->getBeginLoc(), incText, true, true);
         }
         incText += "\n";
-        const Stmt * body = forStmt->getBody();
-        clang::SourceLocation forEndLoc = Lexer::getLocForEndOfToken(forStmt->getEndLoc(), 1, sm, opt);
-        if (!isa<clang::CompoundStmt>(body)) {
-            forEndLoc = forEndLoc.getLocWithOffset(2);
-            incText = "\n" + incText;
-        }
         if (forStmt->getInit()) {
             incText += "\n}";
         }
-        rewriter->InsertText(forEndLoc, "\t" + incText , true, true);
+        const Stmt * body = forStmt->getBody();
+        SourceLocation forEndLoc;
+        if (!isa<CompoundStmt>(body)) {
+            forEndLoc = Lexer::getLocForEndOfToken(forStmt->getEndLoc(), 0, sm, opt).getLocWithOffset(1);
+            incText = "\n" + incText;
+            rewritingStack.push(pair(forEndLoc, incText));
+            if (!isa<ForStmt>(body)) {
+                pair<SourceLocation, string> pair_;
+                while (!rewritingStack.empty()) {
+                    pair_ = rewritingStack.top();
+                    rewriter->InsertText(pair_.first, pair_.second, true, true);
+                    rewritingStack.pop();
+                }
+            }
+        } else {
+            forEndLoc = cast<CompoundStmt>(body)->getRBracLoc();
+            rewriter->InsertText(forEndLoc, "\t" + incText , true, true);
+        }
     }
 }
 

--- a/src/transformations/ForToWhileTransformation.cpp
+++ b/src/transformations/ForToWhileTransformation.cpp
@@ -50,7 +50,7 @@ void ForToWhileVisitor::processInit(ForStmt * forStmt) {
         if (isa<clang::ValueStmt>(*init)) {
             initRange.setEnd(Lexer::getLocForEndOfToken(init->getEndLoc(), 1, sm, opt).getLocWithOffset(1));
         }
-        auto initText = getTextFromRange(initRange) + ";\n";
+        auto initText = "{\n" + getTextFromRange(initRange) + ";\n";
         rewriter->InsertText(forStmt->getBeginLoc(), initText, true, true);
     }
 }
@@ -96,7 +96,10 @@ void ForToWhileVisitor::processInc(ForStmt * forStmt) {
             forEndLoc = forEndLoc.getLocWithOffset(2);
             incText = "\n" + incText;
         }
-        rewriter->InsertText(forEndLoc, "\t" + incText, true, true);
+        if (forStmt->getInit()) {
+            incText += "\n}";
+        }
+        rewriter->InsertText(forEndLoc, "\t" + incText , true, true);
     }
 }
 

--- a/tests/resources/expected/test_for_to_while/transformation_0.cpp
+++ b/tests/resources/expected/test_for_to_while/transformation_0.cpp
@@ -29,6 +29,9 @@ int main(void) {
         int k = 5;
     a(&val);
     int x = 0;
+    for (int i = 1; i <= 5; ++ i)
+        for (int j = 2; j < 6; ++ j)
+            val = 9;
     for(int feeeee=0; feeeee < 3; feeeee++)
         if (1)
             break;

--- a/tests/resources/expected/test_for_to_while/transformation_0.cpp
+++ b/tests/resources/expected/test_for_to_while/transformation_0.cpp
@@ -25,6 +25,8 @@ int main(void) {
     int val = 4;
     for(int i=1000; i < 4000; i++)
         int k = 5;
+    for(int i=1000; i < 4000; i++)
+        int k = 5;
     a(&val);
     int x = 0;
     for(int feeeee=0; feeeee < 3; feeeee++)

--- a/tests/resources/expected/test_for_to_while/transformation_1.cpp
+++ b/tests/resources/expected/test_for_to_while/transformation_1.cpp
@@ -24,7 +24,7 @@ void a(int *x) {
         int d = 4;
         while (d<5) {
             int z;
-	
+
     d--; 
     }    	++k; 
     
@@ -37,23 +37,36 @@ int main(void) {
     int i=1000;
     while (i < 4000) {
         int k = 5;
-	
+
     i++; 
     
     }}    {
     int i=1000;
     while (i < 4000) {
         int k = 5;
-	
+
     i++; 
     
     }}    a(&val);
     int x = 0;
     {
+    int i = 1;
+    while (i <= 5) {
+        {
+        int j = 2;
+        while (j < 6) {
+            val = 9;}
+            ++ j; 
+            
+            }
+            ++ i; 
+            
+            }}
+    {
     int feeeee=0;
     while (feeeee < 3) {
         if (1)
-            break;	
+            break;
             feeeee++; 
             
             }}
@@ -75,7 +88,7 @@ int main(void) {
     {
     om=1;
     while (om<=M) {
-    B[om]=comp[om]-comp[om-1];	
+    B[om]=comp[om]-comp[om-1];
     om++; 
     
     }}

--- a/tests/resources/expected/test_for_to_while/transformation_1.cpp
+++ b/tests/resources/expected/test_for_to_while/transformation_1.cpp
@@ -4,13 +4,16 @@ using namespace std;
 void a(int *x) {
     cout << "hello";
     int second_item = 6;
+    {
     int item = 0;
     while (item < second_item) {
         int d = 4;
     	++item; 
-    }
+    
+    }}
 
     int k;
+    {
     k =   0;
     while (k <   6) {
         if(k == 4) {
@@ -24,41 +27,57 @@ void a(int *x) {
 	
     d--; 
     }    	++k; 
-    }
+    
+    }}
 }
 
 int main(void) {
     int val = 4;
+    {
     int i=1000;
     while (i < 4000) {
         int k = 5;
 	
     i++; 
-    }    a(&val);
+    
+    }}    {
+    int i=1000;
+    while (i < 4000) {
+        int k = 5;
+	
+    i++; 
+    
+    }}    a(&val);
     int x = 0;
+    {
     int feeeee=0;
     while (feeeee < 3) {
         if (1)
             break;	
             feeeee++; 
-            }
+            
+            }}
     int very_long_var = 100;
+    {
     int s = very_long_var;
     while (1) {
         if (s == 6) {
             break;
         }
     	s += 1; 
-    }
+    
+    }}
     a(&x);
     while (x != 0) ;
     while (1) ;
     int om, M;
     int B[2], comp[4];
+    {
     om=1;
     while (om<=M) {
     B[om]=comp[om]-comp[om-1];	
     om++; 
-    }
+    
+    }}
     return 0;
 }

--- a/tests/resources/input/test_for_to_while.cpp
+++ b/tests/resources/input/test_for_to_while.cpp
@@ -29,6 +29,9 @@ int main(void) {
         int k = 5;
     a(&val);
     int x = 0;
+    for (int i = 1; i <= 5; ++ i)
+        for (int j = 2; j < 6; ++ j)
+            val = 9;
     for(int feeeee=0; feeeee < 3; feeeee++)
         if (1)
             break;

--- a/tests/resources/input/test_for_to_while.cpp
+++ b/tests/resources/input/test_for_to_while.cpp
@@ -25,6 +25,8 @@ int main(void) {
     int val = 4;
     for(int i=1000; i < 4000; i++)
         int k = 5;
+    for(int i=1000; i < 4000; i++)
+        int k = 5;
     a(&val);
     int x = 0;
     for(int feeeee=0; feeeee < 3; feeeee++)


### PR DESCRIPTION
In this PR the following issues are fixed:
1. One line nested `for` loop e.g.:
```
for (i = 0; i < n; ++i)
    for (j = 0; j < n; ++j)
        printf("1");
```
2. Processing multiple declarations of the same variable, e.g.:
```
for (int i = 0; i < 3; i++) { ... }
...
for (int i = 3; i < 9; i++) { ... }
```
will be transformed to:
```
{
int i = 0;
while (i < 3) { ... }
}
...
{
int i = 3;
while (i < 9) { ... }
}
```