### PR TITLE
Fix if-else swap

### DIFF
--- a/include/transformations/IfElseSwapTransformation.h
+++ b/include/transformations/IfElseSwapTransformation.h
@@ -47,12 +47,13 @@ class IfElseSwapVisitor : public RecursiveASTVisitor<IfElseSwapVisitor> {
     string getBodyAsString(SourceRange * range);
 };
 
-class ChildFinder : public RecursiveASTVisitor<ChildFinder> {
-public:
-    ChildFinder(const Stmt * leaf);
+/// Class to check if "root" statement has a child "leaf"
+class ChildStmtChecker : public RecursiveASTVisitor<ChildStmtChecker> {
+ public:
+    explicit ChildStmtChecker(const Stmt * leaf);
     bool VisitStmt(Stmt * stmt);
     bool isChild();
-private:
+ private:
     const Stmt * leaf;
     bool isChild_ = false;
 };

--- a/include/transformations/IfElseSwapTransformation.h
+++ b/include/transformations/IfElseSwapTransformation.h
@@ -38,7 +38,9 @@ class IfElseSwapVisitor : public RecursiveASTVisitor<IfElseSwapVisitor> {
     SourceManager & sm;
     LangOptions opt;
     vector<IfStmt *> visitedIfStmt;
-    bool isNotVisited(IfStmt * ifStmt);
+    bool isElseStmtOfVisited(IfStmt * ifStmt);
+    bool isChildOfVisited(IfStmt * ifStmt);
+    bool isChild(Stmt * root, Stmt * leaf);
     void swapBodies(IfStmt * ifStmt);
     void rewriteCondition(IfStmt * ifStmt);
     void processIfStmt(IfStmt * ifStmt);

--- a/include/transformations/IfElseSwapTransformation.h
+++ b/include/transformations/IfElseSwapTransformation.h
@@ -20,7 +20,7 @@
 
 #include "../ITransformation.h"
 
-using clang::ASTConsumer, clang::Rewriter, clang::RecursiveASTVisitor, clang::IfStmt,
+using clang::ASTConsumer, clang::Rewriter, clang::RecursiveASTVisitor, clang::IfStmt, clang::ConstStmtVisitor,
 clang::ASTContext, clang::Stmt, clang::SourceManager, clang::LangOptions, clang::SourceRange;
 using std::unique_ptr, std::vector, std::string;
 
@@ -45,6 +45,16 @@ class IfElseSwapVisitor : public RecursiveASTVisitor<IfElseSwapVisitor> {
     void rewriteCondition(IfStmt * ifStmt);
     void processIfStmt(IfStmt * ifStmt);
     string getBodyAsString(SourceRange * range);
+};
+
+class ChildFinder : public RecursiveASTVisitor<ChildFinder> {
+public:
+    ChildFinder(const Stmt * leaf);
+    bool VisitStmt(Stmt * stmt);
+    bool isChild();
+private:
+    const Stmt * leaf;
+    bool isChild_ = false;
 };
 
 class IfElseSwapASTConsumer : public ASTConsumer {

--- a/src/transformations/IfElseSwapTransformation.cpp
+++ b/src/transformations/IfElseSwapTransformation.cpp
@@ -1,8 +1,8 @@
-#include "../../include/transformations/IfElseSwapTransformation.h"
-#include <vector>
-#include <iostream>
 #include <iterator>
 #include <algorithm>
+
+#include "../../include/transformations/IfElseSwapTransformation.h"
+
 using clang::IfStmt, clang::ForStmt, clang::WhileStmt;
 using clang::Lexer, clang::CharSourceRange;
 using llvm::isa, llvm::cast;
@@ -102,7 +102,7 @@ bool IfElseSwapVisitor::isChildOfVisited(IfStmt * ifStmt) {
             if (it + 1 != visitedIfStmt.rend()) {
                 return !(prev->getElse() == stmt);
             } else {
-                return false;
+                return true;
             }
         }
         // If else part of current stmt is "else if" then change elseStmt to body of "else if"
@@ -113,7 +113,7 @@ bool IfElseSwapVisitor::isChildOfVisited(IfStmt * ifStmt) {
             if (it + 1 != visitedIfStmt.rend()) {
                 return !(prev->getElse() == stmt);
             } else {
-                return false;
+                return true;
             }
         }
     }

--- a/src/transformations/IfElseSwapTransformation.cpp
+++ b/src/transformations/IfElseSwapTransformation.cpp
@@ -79,7 +79,9 @@ bool IfElseSwapVisitor::isElseStmtOfVisited(IfStmt * ifStmt) {
 }
 
 bool IfElseSwapVisitor::isChild(Stmt * root, Stmt * leaf) {
-    return find(root->child_begin(), root->child_end(), leaf) != root->child_end();
+    auto finder = ChildFinder(leaf);
+    finder.TraverseStmt(root);
+    return finder.isChild();
 }
 
 bool IfElseSwapVisitor::isChildOfVisited(IfStmt * ifStmt) {
@@ -102,6 +104,17 @@ bool IfElseSwapVisitor::isChildOfVisited(IfStmt * ifStmt) {
         }
     }
     return false;
+}
+
+ChildFinder::ChildFinder(const Stmt * leaf) : leaf(leaf) {}
+
+bool ChildFinder::VisitStmt(Stmt * stmt) {
+    isChild_ = isChild_ || (stmt == leaf);
+    return true;
+}
+
+bool ChildFinder::isChild() {
+    return isChild_;
 }
 
 // ------------ AddCommentsASTConsumer ------------

--- a/src/transformations/IfElseSwapTransformation.cpp
+++ b/src/transformations/IfElseSwapTransformation.cpp
@@ -89,10 +89,14 @@ bool IfElseSwapVisitor::isChildOfVisited(IfStmt * ifStmt) {
     for (IfStmt * stmt : visitedIfStmt) {
         thenStmt = stmt->getThen();
         elseStmt = stmt->getElse();
+        // If in AST children of thenStmt consists ifStmt
         if (isChild(thenStmt, ifStmt)) {
             return true;
         }
+        // If else part of current stmt is "else if" then change elseStmt to body of "else if"
         elseStmt = isa<IfStmt>(elseStmt) ? cast<IfStmt>(elseStmt)->getThen() : elseStmt;
+        // If in AST children of elseStmt consists ifStmt return
+        // "false" if current stmt has "else if", "true" otherwise
         if (isChild(elseStmt, ifStmt)) {
             return !isa<IfStmt>(stmt->getElse());
         }

--- a/src/transformations/IfElseSwapTransformation.cpp
+++ b/src/transformations/IfElseSwapTransformation.cpp
@@ -38,8 +38,10 @@ void IfElseSwapVisitor::swapBodies(IfStmt * ifStmt) {
     auto elseStmt = ifStmt->getElse();
     // Getting bodies of "if" and "else" statements
     auto ifRange = ifStmt->getThen()->getSourceRange();
+    ifRange.setEnd(Lexer::getLocForEndOfToken(ifRange.getEnd(), 1, sm, opt));
     auto ifBodyText = getBodyAsString(&ifRange);
     auto elseRange = elseStmt->getSourceRange();
+    elseRange.setEnd(Lexer::getLocForEndOfToken(elseRange.getEnd(), 1, sm, opt));
     auto elseBodyText = getBodyAsString(&elseRange);
     // Swap if and else parts
     rewriter->ReplaceText(elseRange, ifBodyText);
@@ -79,9 +81,9 @@ bool IfElseSwapVisitor::isElseStmtOfVisited(IfStmt * ifStmt) {
 }
 
 bool IfElseSwapVisitor::isChild(Stmt * root, Stmt * leaf) {
-    auto finder = ChildFinder(leaf);
-    finder.TraverseStmt(root);
-    return finder.isChild();
+    auto checker = ChildStmtChecker(leaf);
+    checker.TraverseStmt(root);
+    return checker.isChild();
 }
 
 bool IfElseSwapVisitor::isChildOfVisited(IfStmt * ifStmt) {

--- a/src/transformations/IfElseSwapTransformation.cpp
+++ b/src/transformations/IfElseSwapTransformation.cpp
@@ -106,14 +106,16 @@ bool IfElseSwapVisitor::isChildOfVisited(IfStmt * ifStmt) {
     return false;
 }
 
-ChildFinder::ChildFinder(const Stmt * leaf) : leaf(leaf) {}
+// ------------ ChildStmtChecker ------------
 
-bool ChildFinder::VisitStmt(Stmt * stmt) {
+ChildStmtChecker::ChildStmtChecker(const Stmt * leaf) : leaf(leaf) {}
+
+bool ChildStmtChecker::VisitStmt(Stmt * stmt) {
     isChild_ = isChild_ || (stmt == leaf);
     return true;
 }
 
-bool ChildFinder::isChild() {
+bool ChildStmtChecker::isChild() {
     return isChild_;
 }
 

--- a/tests/resources/expected/test_if_else_swap/transformation_0.cpp
+++ b/tests/resources/expected/test_if_else_swap/transformation_0.cpp
@@ -68,5 +68,26 @@ int main() {
             else
                 x += 1 << k;
         }
+    if(x - 1 < 0) {
+        return 1;
+    } else if (x > 0) {
+        for (int mask = 0; mask < 1 << 8; ++mask) {
+            if (x == 5) {
+                if (v[0] % 2) {
+                    x += (x - 1);
+                }
+                if (v[0] & (1 << v[1])) {
+                    x += (x - 2);
+
+                } else {
+                    x++;
+                }
+            } else {
+                x = 0;
+            }
+        }
+    } else {
+        return -1;
+    }
     return 0;
 }

--- a/tests/resources/expected/test_if_else_swap/transformation_0.cpp
+++ b/tests/resources/expected/test_if_else_swap/transformation_0.cpp
@@ -45,11 +45,20 @@ int main() {
     vector<int> v = {1, 2, 3};
     if(foo(x) == 1) {
         int tmp_sz = 11;
+        for(auto &z : v) {
+            if (foo(3) == 0) {
+                v.push_back(x + 2);
+            } else {
+                v[0] = max(14, x);
+            }
+        }
     } else {
-        if(foo(7) == 0) {
-            v.push_back(x);
-        } else {
-            v[0] = max(1, x);
+        for(auto &z : v) {
+            if (foo(7) == 0) {
+                v.push_back(x);
+            } else {
+                v[0] = max(1, x);
+            }
         }
     }
     return 0;

--- a/tests/resources/expected/test_if_else_swap/transformation_0.cpp
+++ b/tests/resources/expected/test_if_else_swap/transformation_0.cpp
@@ -42,5 +42,15 @@ int main() {
     } else {
         return 2;
     }
+    vector<int> v = {1, 2, 3};
+    if(foo(x) == 1) {
+        int tmp_sz = 11;
+    } else {
+        if(foo(7) == 0) {
+            v.push_back(x);
+        } else {
+            v[0] = max(1, x);
+        }
+    }
     return 0;
 }

--- a/tests/resources/expected/test_if_else_swap/transformation_0.cpp
+++ b/tests/resources/expected/test_if_else_swap/transformation_0.cpp
@@ -40,7 +40,7 @@ int main() {
             return 0;
         return a;
     } else {
-        return 2;
+        x = 2;
     }
     vector<int> v = {1, 2, 3};
     if(foo(x) == 1) {

--- a/tests/resources/expected/test_if_else_swap/transformation_0.cpp
+++ b/tests/resources/expected/test_if_else_swap/transformation_0.cpp
@@ -61,5 +61,12 @@ int main() {
             }
         }
     }
+    for (long long k = 0; k < 30; k++)
+        if (1 & (1 << k)) {
+            if (k == -1)
+                continue;
+            else
+                x += 1 << k;
+        }
     return 0;
 }

--- a/tests/resources/expected/test_if_else_swap/transformation_1.cpp
+++ b/tests/resources/expected/test_if_else_swap/transformation_1.cpp
@@ -68,5 +68,26 @@ int main() {
             else
                 continue;
         }
+    if(x - 1 < 0) {
+        return 1;
+    } else if (x > 0) {
+        for (int mask = 0; mask < 1 << 8; ++mask) {
+            if (!(x == 5)) {
+                x = 0;
+            } else {
+                if (v[0] % 2) {
+                    x += (x - 1);
+                }
+                if (v[0] & (1 << v[1])) {
+                    x += (x - 2);
+
+                } else {
+                    x++;
+                }
+            }
+        }
+    } else {
+        return -1;
+    }
     return 0;
 }

--- a/tests/resources/expected/test_if_else_swap/transformation_1.cpp
+++ b/tests/resources/expected/test_if_else_swap/transformation_1.cpp
@@ -61,5 +61,12 @@ int main() {
             }
         }
     }
+    for (long long k = 0; k < 30; k++)
+        if (1 & (1 << k)) {
+            if (!(k == -1))
+                x += 1 << k;
+            else
+                continue;
+        }
     return 0;
 }

--- a/tests/resources/expected/test_if_else_swap/transformation_1.cpp
+++ b/tests/resources/expected/test_if_else_swap/transformation_1.cpp
@@ -40,7 +40,7 @@ int main() {
             a = 4;
         return a;
     } else {
-        return 2;
+        x = 2;
     }
     vector<int> v = {1, 2, 3};
     if(!(foo(x) == 1)) {

--- a/tests/resources/expected/test_if_else_swap/transformation_1.cpp
+++ b/tests/resources/expected/test_if_else_swap/transformation_1.cpp
@@ -44,13 +44,22 @@ int main() {
     }
     vector<int> v = {1, 2, 3};
     if(!(foo(x) == 1)) {
-        if(foo(7) == 0) {
-            v.push_back(x);
-        } else {
-            v[0] = max(1, x);
+        for(auto &z : v) {
+            if (foo(7) == 0) {
+                v.push_back(x);
+            } else {
+                v[0] = max(1, x);
+            }
         }
     } else {
         int tmp_sz = 11;
+        for(auto &z : v) {
+            if (foo(3) == 0) {
+                v.push_back(x + 2);
+            } else {
+                v[0] = max(14, x);
+            }
+        }
     }
     return 0;
 }

--- a/tests/resources/expected/test_if_else_swap/transformation_1.cpp
+++ b/tests/resources/expected/test_if_else_swap/transformation_1.cpp
@@ -42,5 +42,15 @@ int main() {
     } else {
         return 2;
     }
+    vector<int> v = {1, 2, 3};
+    if(!(foo(x) == 1)) {
+        if(foo(7) == 0) {
+            v.push_back(x);
+        } else {
+            v[0] = max(1, x);
+        }
+    } else {
+        int tmp_sz = 11;
+    }
     return 0;
 }

--- a/tests/resources/input/test_if_else_swap.cpp
+++ b/tests/resources/input/test_if_else_swap.cpp
@@ -68,5 +68,26 @@ int main() {
             else
                 x += 1 << k;
         }
+    if(x - 1 < 0) {
+        return 1;
+    } else if (x > 0) {
+        for (int mask = 0; mask < 1 << 8; ++mask) {
+            if (x == 5) {
+                if (v[0] % 2) {
+                    x += (x - 1);
+                }
+                if (v[0] & (1 << v[1])) {
+                    x += (x - 2);
+
+                } else {
+                    x++;
+                }
+            } else {
+                x = 0;
+            }
+        }
+    } else {
+        return -1;
+    }
     return 0;
 }

--- a/tests/resources/input/test_if_else_swap.cpp
+++ b/tests/resources/input/test_if_else_swap.cpp
@@ -45,11 +45,20 @@ int main() {
     vector<int> v = {1, 2, 3};
     if(foo(x) == 1) {
         int tmp_sz = 11;
+        for(auto &z : v) {
+            if (foo(3) == 0) {
+                v.push_back(x + 2);
+            } else {
+                v[0] = max(14, x);
+            }
+        }
     } else {
-        if(foo(7) == 0) {
-            v.push_back(x);
-        } else {
-            v[0] = max(1, x);
+        for(auto &z : v) {
+            if (foo(7) == 0) {
+                v.push_back(x);
+            } else {
+                v[0] = max(1, x);
+            }
         }
     }
     return 0;

--- a/tests/resources/input/test_if_else_swap.cpp
+++ b/tests/resources/input/test_if_else_swap.cpp
@@ -42,5 +42,15 @@ int main() {
     } else {
         return 2;
     }
+    vector<int> v = {1, 2, 3};
+    if(foo(x) == 1) {
+        int tmp_sz = 11;
+    } else {
+        if(foo(7) == 0) {
+            v.push_back(x);
+        } else {
+            v[0] = max(1, x);
+        }
+    }
     return 0;
 }

--- a/tests/resources/input/test_if_else_swap.cpp
+++ b/tests/resources/input/test_if_else_swap.cpp
@@ -40,7 +40,7 @@ int main() {
             return 0;
         return a;
     } else {
-        return 2;
+        x = 2;
     }
     vector<int> v = {1, 2, 3};
     if(foo(x) == 1) {

--- a/tests/resources/input/test_if_else_swap.cpp
+++ b/tests/resources/input/test_if_else_swap.cpp
@@ -61,5 +61,12 @@ int main() {
             }
         }
     }
+    for (long long k = 0; k < 30; k++)
+        if (1 & (1 << k)) {
+            if (k == -1)
+                continue;
+            else
+                x += 1 << k;
+        }
     return 0;
 }


### PR DESCRIPTION
1. Nested `if`. Since it was quite difficult to deal with nested `if`, only the top-level `if` statement will be transformed 
``` 
if (x == 0) {
    Block1
    if (y == 0) {
        ...
    } else {
        ...
    }
    Block2
} else {
    Block3
}
```
will be transformed to (note that nested `if` is not transformed)
``` 
if (!(x == 0)) {
    Block3
} else {
    Block1
    if (y == 0) {
        ...
    } else {
        ...
    }
    Block2
}
```
2. `else if`. The code inside `else if` statement is always transformed, but `if` and `else` sections will remain unchanged
``` 
if (...) {
   Block1
} else if (..) {
    CodeToBeTransformed
} else {
   Block2
}
```