### PR TITLE
Fix transform per batch

### DIFF
--- a/include/Runner.h
+++ b/include/Runner.h
@@ -32,12 +32,11 @@ class Runner {
                              const string& output_path,
                              vector<char **> * rewritable_cpaths,
                              vector<vector<vector<string> *> *> * rewritable_string_paths,
-                             size_t * num_files);
-    static void createDescriptionFile(const string& input_path,
-                                      const string& output_path,
+                             size_t * num_files) const const;
+    static void createDescriptionFile(const string& file_path,
                                       const string &description);
     void createOptionsParser(size_t num_files, vector<char **> * rewritable_cpaths,
-                             vector<CommonOptionsParser *> * option_parsers);
+                             vector<CommonOptionsParser *> * option_parsers) const;
     const vector<ITransformation * > * transformations;
     size_t n_transformations;
     size_t batch_size;

--- a/src/Runner.cpp
+++ b/src/Runner.cpp
@@ -174,7 +174,6 @@ void Runner::run(const string& input_path, const string& output_path) {
         for (const auto &descr : file_descr.second) {
             description += descr;
         }
-        std::cout << "descr " << file_descr.first << "\n";
         createDescriptionFile(file_descr.first, description);
     }
 }


### PR DESCRIPTION
Fix the order of applying transformations per batch. Currently, during batchwise processing of files, every single batch has its own set of randomly selected transformations